### PR TITLE
feat: Permission Evaluator를 구현하고 적용한다. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	// validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
+	// spring session jdbc
+	implementation 'org.springframework.session:spring-session-jdbc'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/study/tipsyboy/tipsyboyMall/config/MethodSecurityConfig.java
+++ b/src/main/java/study/tipsyboy/tipsyboyMall/config/MethodSecurityConfig.java
@@ -1,9 +1,26 @@
 package study.tipsyboy.tipsyboyMall.config;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import study.tipsyboy.tipsyboyMall.config.permission.OrderPermissionEvaluator;
+import study.tipsyboy.tipsyboyMall.order.domain.OrderRepository;
 
+@RequiredArgsConstructor
 @EnableMethodSecurity
 @Configuration
 public class MethodSecurityConfig {
+
+    private final OrderRepository orderRepository;
+
+    @Bean
+    public MethodSecurityExpressionHandler methodSecurityExpressionHandler() {
+        DefaultMethodSecurityExpressionHandler handler = new DefaultMethodSecurityExpressionHandler();
+        handler.setPermissionEvaluator(new OrderPermissionEvaluator(orderRepository));
+
+        return handler;
+    }
 }

--- a/src/main/java/study/tipsyboy/tipsyboyMall/config/permission/OrderPermissionEvaluator.java
+++ b/src/main/java/study/tipsyboy/tipsyboyMall/config/permission/OrderPermissionEvaluator.java
@@ -1,0 +1,44 @@
+package study.tipsyboy.tipsyboyMall.config.permission;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+import study.tipsyboy.tipsyboyMall.auth.dto.LoginMember;
+import study.tipsyboy.tipsyboyMall.order.domain.Order;
+import study.tipsyboy.tipsyboyMall.order.domain.OrderRepository;
+import study.tipsyboy.tipsyboyMall.order.exception.OrderException;
+import study.tipsyboy.tipsyboyMall.order.exception.OrderExceptionType;
+
+import java.io.Serializable;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OrderPermissionEvaluator implements PermissionEvaluator {
+
+    private final OrderRepository orderRepository;
+
+    @Override
+    public boolean hasPermission(Authentication authentication,
+                                 Serializable targetId,
+                                 String targetType,
+                                 Object permission) {
+        log.info("[Order - Permission Evaluator]");
+
+        LoginMember loginMember = (LoginMember) authentication.getPrincipal();
+        Order order = orderRepository.findById((Long) targetId)
+                .orElseThrow(() -> new OrderException(OrderExceptionType.ORDER_NOT_FOUND));
+
+        if (!order.getMemberId().equals(loginMember.getMemberId())) {
+            log.error("[인가 실패] 해당 주문의 권한이 없습니다. orderId={}", order.getId());
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public boolean hasPermission(Authentication authentication, Object targetDomainObject, Object permission) {
+        return false;
+    }
+}

--- a/src/main/java/study/tipsyboy/tipsyboyMall/order/api/OrderApiController.java
+++ b/src/main/java/study/tipsyboy/tipsyboyMall/order/api/OrderApiController.java
@@ -5,7 +5,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import study.tipsyboy.tipsyboyMall.auth.dto.LoginMember;
 import study.tipsyboy.tipsyboyMall.order.dto.OrderCreateDto;
 import study.tipsyboy.tipsyboyMall.order.dto.OrderInfoResponseDto;
 import study.tipsyboy.tipsyboyMall.order.service.OrderService;
@@ -20,18 +22,20 @@ public class OrderApiController {
 
     @PostMapping
     @PreAuthorize("hasRole('ROLE_MEMBER')")
-    public ResponseEntity<OrderInfoResponseDto> createOrder(@RequestBody OrderCreateDto orderCreateDto) {
-        return ResponseEntity.ok(orderService.order(orderCreateDto));
+    public ResponseEntity<OrderInfoResponseDto> createOrder(@AuthenticationPrincipal LoginMember loginMember,
+                                                            @RequestBody OrderCreateDto orderCreateDto) {
+        return ResponseEntity.ok(orderService.order(loginMember.getMemberId(), orderCreateDto));
     }
 
-    @GetMapping("/{orderId}") // TODO: ADMIN OR MEMBERS with permissions to view
+    @GetMapping("/{orderId}")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || (hasRole('ROLE_MEMBER') && hasPermission(#orderId, 'ORDER', 'READ'))")
     public ResponseEntity<OrderInfoResponseDto> getOrderInfo(@PathVariable Long orderId) {
         return ResponseEntity.ok(orderService.findOrderById(orderId));
     }
 
     @DeleteMapping("/{orderId}")
+    @PreAuthorize("hasRole('ROLE_ADMIN') || (hasRole('ROLE_MEMBER') && hasPermission(#orderId, 'ORDER', 'DELETE'))")
     public ResponseEntity<Void> cancelOrder(@PathVariable Long orderId) {
-        // TODO: Permission Evaluator 구현 && 삭제 권한 추가
         orderService.cancelOrder(orderId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/study/tipsyboy/tipsyboyMall/order/domain/Order.java
+++ b/src/main/java/study/tipsyboy/tipsyboyMall/order/domain/Order.java
@@ -33,7 +33,8 @@ public class Order extends BaseTimeEntity {
     private Member member;
 
     @Builder
-    public Order(OrderStatus orderStatus, List<OrderItem> orderItems) {
+    public Order(OrderStatus orderStatus, List<OrderItem> orderItems, Member member) {
+        setMember(member);
         this.orderStatus = orderStatus;
         for (OrderItem orderItem : orderItems) {
             this.addOrderItems(orderItem);
@@ -49,5 +50,14 @@ public class Order extends BaseTimeEntity {
     private void addOrderItems(OrderItem orderItem) {
         this.orderItems.add(orderItem);
         orderItem.connectOrder(this);
+    }
+
+    public Long getMemberId() {
+        return this.getMember().getId();
+    }
+
+    private void setMember(Member member) {
+        this.member = member;
+        member.getOrderList().add(this);
     }
 }

--- a/src/main/java/study/tipsyboy/tipsyboyMall/order/service/OrderService.java
+++ b/src/main/java/study/tipsyboy/tipsyboyMall/order/service/OrderService.java
@@ -5,6 +5,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import study.tipsyboy.tipsyboyMall.auth.domain.Member;
+import study.tipsyboy.tipsyboyMall.auth.domain.MemberRepository;
+import study.tipsyboy.tipsyboyMall.auth.exception.AuthException;
+import study.tipsyboy.tipsyboyMall.auth.exception.AuthExceptionType;
 import study.tipsyboy.tipsyboyMall.item.domain.Item;
 import study.tipsyboy.tipsyboyMall.item.domain.ItemRepository;
 import study.tipsyboy.tipsyboyMall.item.exception.ItemException;
@@ -28,15 +32,20 @@ import java.util.stream.Collectors;
 @Service
 public class OrderService {
 
+    private final MemberRepository memberRepository;
     private final ItemRepository itemRepository;
     private final OrderRepository orderRepository;
 
     @Transactional
-    public OrderInfoResponseDto order(OrderCreateDto orderCreateDto) {
+    public OrderInfoResponseDto order(Long memberId, OrderCreateDto orderCreateDto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new AuthException(AuthExceptionType.AUTH_NOT_FOUND));
+
         List<OrderItem> orderItems = orderCreateDto.getOrderInfo().entrySet().stream()
                 .map(this::createOrderItem)
                 .collect(Collectors.toList());
         Order order = Order.builder()
+                .member(member)
                 .orderItems(orderItems)
                 .orderStatus(OrderStatus.ORDER)
                 .build();

--- a/src/test/java/study/tipsyboy/tipsyboyMall/item/api/ItemApiControllerTest.java
+++ b/src/test/java/study/tipsyboy/tipsyboyMall/item/api/ItemApiControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import study.tipsyboy.tipsyboyMall.annotation.CustomWithMockUser;
+import study.tipsyboy.tipsyboyMall.auth.domain.MemberRepository;
 import study.tipsyboy.tipsyboyMall.item.domain.Item;
 import study.tipsyboy.tipsyboyMall.item.domain.ItemRepository;
 import study.tipsyboy.tipsyboyMall.item.dto.ItemCreateDto;
@@ -37,8 +38,12 @@ class ItemApiControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
     @AfterEach
     public void after() {
+        memberRepository.deleteAll();
         itemRepository.deleteAll();
     }
 

--- a/src/test/java/study/tipsyboy/tipsyboyMall/order/api/OrderApiControllerTest.java
+++ b/src/test/java/study/tipsyboy/tipsyboyMall/order/api/OrderApiControllerTest.java
@@ -9,7 +9,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 import study.tipsyboy.tipsyboyMall.annotation.CustomWithMockUser;
+import study.tipsyboy.tipsyboyMall.auth.domain.Member;
+import study.tipsyboy.tipsyboyMall.auth.domain.MemberRepository;
 import study.tipsyboy.tipsyboyMall.auth.domain.MemberRole;
 import study.tipsyboy.tipsyboyMall.item.domain.Item;
 import study.tipsyboy.tipsyboyMall.item.domain.ItemRepository;
@@ -42,6 +45,9 @@ class OrderApiControllerTest {
     private OrderService orderService;
 
     @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
     private OrderRepository orderRepository;
 
     @Autowired
@@ -52,6 +58,7 @@ class OrderApiControllerTest {
 
     @AfterEach
     public void after() {
+        memberRepository.deleteAll();
         orderRepository.deleteAll();
         itemRepository.deleteAll();
     }
@@ -164,10 +171,12 @@ class OrderApiControllerTest {
     }
 
     @Test
+    @Transactional
     @CustomWithMockUser(memberRole = MemberRole.MEMBER)
     @DisplayName("주문을 취소한다.")
     public void cancelOrder() throws Exception {
         // given
+        Member member = memberRepository.findAll().get(0);
         Item item = Item.builder()
                 .itemName("피자 먹고싶다.")
                 .price(10000)
@@ -185,6 +194,7 @@ class OrderApiControllerTest {
         Order order = Order.builder()
                 .orderItems(List.of(orderItem))
                 .orderStatus(OrderStatus.ORDER)
+                .member(member)
                 .build();
         orderRepository.save(order);
 


### PR DESCRIPTION
##Summary
feat: Permission Evaluator를 구현하고 적용한다. 

##Tasks

- chore: 시큐리티 jdbc 세션 의존성 추가
- feat: permission evaluator를 구현하고, 메서드 시큐리티에 적용한다.

- refactor: 관련 api에 permission 조건을 추가한다.
- refactor: permission을 위해 Order-Member 연관관계를 설정하고, 관련 로직들을 수정한다.

- test: permission 관련 테스트들을 작성/수정한다. - JPA lazy로딩 오류로 인해 @Transactinal 어노테이션 추가

##More
close #30